### PR TITLE
CTCP-2110: Add simple logging for EIS failures

### DIFF
--- a/it/uk/gov/hmrc/ctcguaranteebalancerouter/connectors/WiremockSuite.scala
+++ b/it/uk/gov/hmrc/ctcguaranteebalancerouter/connectors/WiremockSuite.scala
@@ -30,7 +30,9 @@ trait WiremockSuite extends BeforeAndAfterAll with BeforeAndAfterEach {
   protected val wiremockPort = 11111
 
   protected val wiremockConfig =
-    wireMockConfig().port(wiremockPort).notifier(new ConsoleNotifier(false))
+    wireMockConfig()
+      .port(wiremockPort)
+      .notifier(new ConsoleNotifier(false))
 
   protected val server: WireMockServer = new WireMockServer(wiremockConfig)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "1.9.3")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.0")


### PR DESCRIPTION
We've been facing an intermittent failure in either our router or stub and we aren't quite sure which one is failing, or why. This logging is useful for logging failures when connecting to EIS anyway, but does so in a way that won't leak any PII.

This will support our investigation into the failing regression tests if it happens again.